### PR TITLE
PL-5544 Fix akka-http-documenteddsl so it compiles for Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
+# by default Travis uses JDK 8u31, which is much too old for Scala 2.12 (versions before 8u102 have issues - https://issues.scala-lang.org/browse/SI-9828)
+dist: trusty
+sudo: false
+
 language: scala
 
 scala:
   - 2.11.11
-#  - 2.12.2
+  - 2.12.3
 
 jdk: oraclejdk8
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -16,9 +16,9 @@ object BuildSettings {
     organizationName      := "Evolution Gaming",
     organizationHomepage  := Some(url("http://evolutiongaming.com")),
     bintrayOrganization   := Some("evolutiongaming"),
-    scalaVersion          := "2.11.11",
-//    crossScalaVersions    := Seq("2.11.11", "2.12.2"),
-//    releaseCrossBuild     := true,
+    scalaVersion          := "2.12.3",
+    crossScalaVersions    := Seq("2.11.11", "2.12.3"),
+    releaseCrossBuild     := true,
     licenses              := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     scalacOptions         ++= Seq(
       "-encoding", "UTF-8",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/src/main/scala/akka/http/documenteddsl/DDirectives.scala
+++ b/src/main/scala/akka/http/documenteddsl/DDirectives.scala
@@ -1,7 +1,7 @@
 package akka.http.documenteddsl
 
 import akka.http.documenteddsl.directives._
-import akka.http.scaladsl.server.directives.RouteDirectives.{redirect => akkaRedirect}
+
 
 trait DDirectives
   extends DRouteConcatenation
@@ -21,7 +21,6 @@ object DDirectives extends DDirectives {
   type DDirective[T]  = akka.http.documenteddsl.directives.DDirective[T]
   type DDirective0    = akka.http.documenteddsl.directives.DDirective0
   type DDirective1[T] = akka.http.documenteddsl.directives.DDirective1[T]
-
   type DRoute         = akka.http.documenteddsl.DRoute
 
 }

--- a/src/main/scala/akka/http/documenteddsl/DRouteConcatenation.scala
+++ b/src/main/scala/akka/http/documenteddsl/DRouteConcatenation.scala
@@ -2,7 +2,7 @@ package akka.http.documenteddsl
 
 import akka.http.documenteddsl.directives.RouteDDirectives
 import akka.http.documenteddsl.documentation.Documentation
-import akka.http.scaladsl.server.{Route, RouteConcatenation}
+import akka.http.scaladsl.server.RouteConcatenation
 
 import scala.language.implicitConversions
 

--- a/src/main/scala/akka/http/documenteddsl/directives/DDirective.scala
+++ b/src/main/scala/akka/http/documenteddsl/directives/DDirective.scala
@@ -11,7 +11,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
 import org.coursera.autoschema.AutoSchema
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContextExecutor
 import scala.language.implicitConversions
 
 trait DDirective[L] { self =>
@@ -78,7 +78,7 @@ object DDirective {
     parserSettings:   ParserSettings,
     materializer:     Materializer,
     routingLog:       RoutingLog,
-    executionContext: ExecutionContext = null,
+    executionContext: ExecutionContextExecutor = null,
     rejectionHandler: RejectionHandler = RejectionHandler.default,
     exceptionHandler: ExceptionHandler = null): Flow[HttpRequest, HttpResponse, NotUsed] = Route.handlerFlow(route)
 

--- a/src/main/scala/akka/http/documenteddsl/directives/HeaderDDirectives.scala
+++ b/src/main/scala/akka/http/documenteddsl/directives/HeaderDDirectives.scala
@@ -1,17 +1,14 @@
 package akka.http.documenteddsl.directives
 
-import akka.http.documenteddsl.documentation.{ParamDocumentation, RouteDocumentation}
-import akka.http.scaladsl.model.StatusCodes._
+import akka.http.documenteddsl.documentation.RouteDocumentation
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives._
-import akka.http.scaladsl.unmarshalling._
 import org.coursera.autoschema.AutoSchema
 
 import scala.reflect.ClassTag
-import scala.reflect.runtime.{universe => ru}
 
 trait HeaderDDirectives {
   sealed trait Header[T] extends DDirective1[T]
@@ -25,7 +22,7 @@ trait HeaderDDirectives {
     }
   }
 
-  case class HeaderByType[T <: HttpHeader](implicit ct: ClassTag[T]) extends Header[T] {
+  case class HeaderByType[T <: HttpHeader]()(implicit ct: ClassTag[T]) extends Header[T] {
     def describe(w: RouteDocumentation)(implicit as: AutoSchema): RouteDocumentation = {
       w.header(ModeledCompanion.nameFromClass(ct.runtimeClass), required = true, constraints = None)
     }

--- a/src/main/scala/akka/http/documenteddsl/directives/MarshallingDDirectives.scala
+++ b/src/main/scala/akka/http/documenteddsl/directives/MarshallingDDirectives.scala
@@ -3,15 +3,14 @@ package akka.http.documenteddsl.directives
 import akka.http.documenteddsl.PreprocessedFromEntityUnmarshaller
 import akka.http.documenteddsl.documentation.RouteDocumentation
 import akka.http.scaladsl.server.Directive1
-import akka.http.scaladsl.unmarshalling._
 import org.coursera.autoschema.AutoSchema
-import play.api.libs.json.{Reads, Writes}
+import play.api.libs.json.Writes
 
 import scala.reflect.runtime.{universe => ru}
 
 trait MarshallingDDirectives {
 
-  final class In[T](example: Option[T] = None)(implicit um: PreprocessedFromEntityUnmarshaller[T], ev: ru.TypeTag[T], writes: Writes[T], reads: Reads[T]) extends DDirective1[T] {
+  final class In[T](example: Option[T] = None)(implicit um: PreprocessedFromEntityUnmarshaller[T], ev: ru.TypeTag[T], writes: Writes[T]) extends DDirective1[T] {
     import akka.http.scaladsl.server.directives.MarshallingDirectives._
     import um.fsu
     def describe(w: RouteDocumentation)(implicit as: AutoSchema): RouteDocumentation = w.in[T](example map writes.writes)
@@ -19,8 +18,8 @@ trait MarshallingDDirectives {
   }
 
   object In {
-    def apply[T](implicit um: PreprocessedFromEntityUnmarshaller[T], ev: ru.TypeTag[T], writes: Writes[T], reads: Reads[T]): In[T] = new In()
-    def apply[T](example: T)(implicit um: PreprocessedFromEntityUnmarshaller[T], ev: ru.TypeTag[T], writes: Writes[T], reads: Reads[T]): In[T] = new In(Some(example))
+    def apply[T](implicit um: PreprocessedFromEntityUnmarshaller[T], ev: ru.TypeTag[T], writes: Writes[T]): In[T] = new In()
+    def apply[T](example: T)(implicit um: PreprocessedFromEntityUnmarshaller[T], ev: ru.TypeTag[T], writes: Writes[T]): In[T] = new In(Some(example))
   }
 }
 

--- a/src/main/scala/akka/http/documenteddsl/documentation/RouteDocumentation.scala
+++ b/src/main/scala/akka/http/documenteddsl/documentation/RouteDocumentation.scala
@@ -86,7 +86,7 @@ case class RouteDocumentation(
     parameters(param :: Nil)
   }
 
-  def parameters(params: List[ParamDocumentation])(implicit as: AutoSchema): RouteDocumentation = {
+  def parameters(params: List[ParamDocumentation]): RouteDocumentation = {
     val joined = (parameters, params) match {
       case (None   , Nil)  => None
       case (None   , y)    => Some(y)

--- a/src/test/scala/akka/http/documenteddsl/HeaderDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/HeaderDDirectivesSpec.scala
@@ -1,12 +1,12 @@
 package akka.http.documenteddsl
 
-import DDirectives._
+import akka.http.documenteddsl.DDirectives._
 import akka.http.documenteddsl.documentation._
+import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.headers._
-import akka.http.scaladsl.model.{ContentTypes, HttpHeader}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.WordSpec
 import org.scalatest.MustMatchers._
+import org.scalatest.WordSpec
 
 class HeaderDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
 

--- a/src/test/scala/akka/http/documenteddsl/PathDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/PathDDirectivesSpec.scala
@@ -2,9 +2,8 @@ package akka.http.documenteddsl
 
 import java.time.LocalDate
 
-import DDirectives._
-import akka.http.scaladsl.server.directives.RouteDirectives
-import documentation._
+import akka.http.documenteddsl.DDirectives._
+import akka.http.documenteddsl.documentation._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.MustMatchers._
 import org.scalatest.WordSpec

--- a/src/test/scala/akka/http/documenteddsl/UnmarshallingDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/UnmarshallingDDirectivesSpec.scala
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import akka.http.documenteddsl.directives.UnmarshallingDDirectives._
 import akka.http.documenteddsl.documentation.OutDocumentation._
 import akka.http.documenteddsl.documentation.{JsonSchema, OutDocumentation, RouteDocumentation}
-import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.MustMatchers._
 import org.scalatest.WordSpec


### PR DESCRIPTION
in addition:
* upgrade to SBT 0.13.16
* enable JDK 8u131 on Travis
* fix Scala code according to scalac warnings