### PR TITLE
update libraries and release workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,28 +13,26 @@ jobs:
           - 2.13.18
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: coursier/cache-action@v3
+      - uses: coursier/cache-action@v6
 
-      - name: scala
-        uses: olafurpg/setup-scala@v10
+      - name: setup Java 17
+        uses: actions/setup-java@v4
         with:
-          java-version: openjdk@1.11
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'sbt'
+
+      - name: setup SBT
+        uses: sbt/setup-sbt@v1
 
       - name: build ${{ matrix.scala }}
         run: sbt ++${{ matrix.scala }} clean coverage test
 
       - name: test coverage
         if: success()
+        run: sbt ++${{ matrix.scala }} coverageAggregate coveralls
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
-
-      - name: slack
-        uses: homoluctus/slatify@master
-        if: failure() && github.ref == 'refs/heads/master'
-        with:
-          type: ${{ job.status }}
-          job_name: Build
-          url: ${{ secrets.SLACK_WEBHOOK }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         scala:
           - 2.13.18
-          - 2.12.12
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - 2.13.3
+          - 2.13.18
           - 2.12.12
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v1
+    uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@v4
     secrets: inherit

--- a/build.sbt
+++ b/build.sbt
@@ -11,15 +11,24 @@ val alias: Seq[sbt.Def.Setting[_]] =
     addCommandAlias("build", "+all compile test")
 
 lazy val project = (Project(artifactId, file("."))
-  configs ExamplesConfig
-  settings inConfig(ExamplesConfig)(compileBase ++ compileSettings ++ Seq(
-  run := Defaults.runTask(fullClasspath in ExamplesConfig, mainClass in run, runner in run).evaluated,
-  runMain := Defaults.runMainTask(fullClasspath in ExamplesConfig, runner in run).evaluated))
-  settings alias
-  settings basicSettings
-  settings Seq(
+  .configs(ExamplesConfig)
+  .settings (
+    inConfig(ExamplesConfig)(compileBase ++ compileSettings ++ Seq(
+      run := Defaults.runTask(ExamplesConfig / fullClasspath , run / mainClass , run / runner).evaluated,
+      runMain := Defaults.runMainTask(ExamplesConfig / fullClasspath, run / runner).evaluated)
+    ),
+  )
+  .settings(alias)
+  .settings(basicSettings)
+  .settings(Seq(
     libraryDependencies ++= Seq(
-      akkaHttpCore, akkaHttp, akkaHttpTestKit, akkaHttpPlayJson,
-      akkaStream, akkaStreamTestkit,
+      akkaHttpCore,
+      akkaHttp,
+      akkaHttpTestKit,
+      akkaHttpPlayJson,
+      akkaStream,
+      akkaStreamTestkit,
       jsonSchema,
-      scalaTest, mockito)))
+      scalaTest,
+      mockito))),
+  )

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -15,7 +15,7 @@ object BuildSettings {
     organizationName      := "Evolution",
     organizationHomepage  := Some(url("https://evolution.com")),
     scalaVersion          := crossScalaVersions.value.head,
-    crossScalaVersions    := Seq("2.13.18", "2.12.12"),
+    crossScalaVersions    := Seq("2.13.18"),
     releaseCrossBuild     := true,
     publishTo             := Some(Resolver.evolutionReleases),
     licenses              := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))))

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -15,7 +15,7 @@ object BuildSettings {
     organizationName      := "Evolution",
     organizationHomepage  := Some(url("https://evolution.com")),
     scalaVersion          := crossScalaVersions.value.head,
-    crossScalaVersions    := Seq("2.13.3", "2.12.12"),
+    crossScalaVersions    := Seq("2.13.18", "2.12.12"),
     releaseCrossBuild     := true,
     publishTo             := Some(Resolver.evolutionReleases),
     licenses              := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))))

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,7 +1,6 @@
 import sbt._
 import sbt.Keys._
 import sbt.Defaults._
-import sbtrelease.ReleasePlugin.autoImport.releaseCrossBuild
 import com.evolution.artifactory.ArtifactoryPlugin.autoImport.ResolverOpsArtifactory
 
 object BuildSettings {
@@ -16,7 +15,6 @@ object BuildSettings {
     organizationHomepage  := Some(url("https://evolution.com")),
     scalaVersion          := crossScalaVersions.value.head,
     crossScalaVersions    := Seq("2.13.18"),
-    releaseCrossBuild     := true,
     publishTo             := Some(Resolver.evolutionReleases),
     licenses              := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,5 +11,5 @@ object Dependencies {
   val akkaHttpPlayJson  = "com.evolutiongaming" %% "akka-http-play-json"  % "0.3.0"
   val jsonSchema        = "com.evolutiongaming" %% "autoschema"           % "1.0.5"
   val scalaTest         = "org.scalatest"       %% "scalatest"            % "3.2.20" % Test
-  val mockito           = "org.mockito"          % "mockito-core"         % "3.4.4" % Test
+  val mockito           = "org.mockito"          % "mockito-core"         % "5.23.0" % Test
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val akkaHttpTestKit   = "com.typesafe.akka"   %% "akka-http-testkit"    % AkkaHttpVersion % Test
   val akkaStream        = "com.typesafe.akka"   %% "akka-stream"          % AkkaVersion
   val akkaStreamTestkit = "com.typesafe.akka"   %% "akka-stream-testkit"  % AkkaVersion % Test
-  val akkaHttpPlayJson  = "com.evolutiongaming" %% "akka-http-play-json"  % "0.1.13"
+  val akkaHttpPlayJson  = "com.evolutiongaming" %% "akka-http-play-json"  % "0.3.0"
   val jsonSchema        = "com.evolutiongaming" %% "autoschema"           % "1.0.5"
   val scalaTest         = "org.scalatest"       %% "scalatest"            % "3.0.8" % Test
   val mockito           = "org.mockito"          % "mockito-core"         % "3.4.4" % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,6 @@ object Dependencies {
   val akkaStreamTestkit = "com.typesafe.akka"   %% "akka-stream-testkit"  % AkkaVersion % Test
   val akkaHttpPlayJson  = "com.evolutiongaming" %% "akka-http-play-json"  % "0.3.0"
   val jsonSchema        = "com.evolutiongaming" %% "autoschema"           % "1.0.5"
-  val scalaTest         = "org.scalatest"       %% "scalatest"            % "3.0.8" % Test
+  val scalaTest         = "org.scalatest"       %% "scalatest"            % "3.2.20" % Test
   val mockito           = "org.mockito"          % "mockito-core"         % "3.4.4" % Test
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val AkkaHttpVersion = "10.1.11"
-  val AkkaVersion = "2.6.3"
+  val AkkaHttpVersion = "10.2.10" // `10.2.10` is last open source version before switch to BSL
+  val AkkaVersion = "2.6.21" // `2.6.21` is last open source version before switch to BSL
   val akkaHttpCore      = "com.typesafe.akka"   %% "akka-http-core"       % AkkaHttpVersion
   val akkaHttp          = "com.typesafe.akka"   %% "akka-http"            % AkkaHttpVersion
   val akkaHttpTestKit   = "com.typesafe.akka"   %% "akka-http-testkit"    % AkkaHttpVersion % Test

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.5
+sbt.version = 1.12.14

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.7.1")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 
 addSbtPlugin("com.evolution" % "sbt-scalac-opts-plugin" % "0.0.9")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.7.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.3.15")
 
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 

--- a/src/main/scala/akka/http/documenteddsl/directives/DDirective.scala
+++ b/src/main/scala/akka/http/documenteddsl/directives/DDirective.scala
@@ -1,17 +1,14 @@
 package akka.http.documenteddsl.directives
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.http.documenteddsl._
 import akka.http.documenteddsl.documentation._
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.util.{ApplyConverter, Tuple, TupleOps, Tupler}
-import akka.http.scaladsl.settings.{ParserSettings, RoutingSettings}
-import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
 import org.coursera.autoschema.AutoSchema
-
-import scala.concurrent.ExecutionContextExecutor
 
 trait DDirective[L] { self =>
   def describe(w: RouteDocumentation)(implicit as: AutoSchema): RouteDocumentation
@@ -74,13 +71,9 @@ object DDirective {
   }
 
   implicit def documentedRoute2HandlerFlow(route: DRoute)(implicit
-    routingSettings:  RoutingSettings,
-    parserSettings:   ParserSettings,
-    materializer:     Materializer,
-    routingLog:       RoutingLog,
-    executionContext: ExecutionContextExecutor = null,
-    rejectionHandler: RejectionHandler = RejectionHandler.default,
-    exceptionHandler: ExceptionHandler = null): Flow[HttpRequest, HttpResponse, NotUsed] = Route.handlerFlow(route)
+    actorSystem: ActorSystem,
+  ): Flow[HttpRequest, HttpResponse, NotUsed] =
+      Route.toFlow(route)
 
 }
 

--- a/src/main/scala/akka/http/documenteddsl/documentation/DocumentationJson.scala
+++ b/src/main/scala/akka/http/documenteddsl/documentation/DocumentationJson.scala
@@ -15,11 +15,11 @@ trait DocumentationJson {
     }
   }
 
-  implicit val originWrites = new Writes[Origin]() {
+  implicit val originWrites: Writes[Origin] = new Writes[Origin]() {
     override def writes(o: Origin): JsValue = JsString(o.productPrefix.toLowerCase)
   }
   
-  implicit def pathWrites = new Writes[PathDocumentation]() {
+  implicit def pathWrites: Writes[PathDocumentation] = new Writes[PathDocumentation]() {
     override def writes(o: PathDocumentation): JsValue = JsString(o.render())
   }
 

--- a/src/test/scala/akka/http/documenteddsl/DConjunctionMagnetSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/DConjunctionMagnetSpec.scala
@@ -3,10 +3,9 @@ package akka.http.documenteddsl
 import akka.http.scaladsl.server.directives.MethodDirectives
 import akka.http.scaladsl.server.Directive0
 import DDirectives.{DDirective0, Title}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-
-class DConjunctionMagnetSpec extends WordSpec with DDirectivesSpec {
+class DConjunctionMagnetSpec extends AnyWordSpec with DDirectivesSpec {
 
   "DConjunctionMagnet" must {
     "be able to be made of Directive and DDirective conjunction" in {

--- a/src/test/scala/akka/http/documenteddsl/DocumentationDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/DocumentationDDirectivesSpec.scala
@@ -2,10 +2,10 @@ package akka.http.documenteddsl
 
 import akka.http.documenteddsl.directives.DocumentationDDirectives._
 import akka.http.documenteddsl.documentation.RouteDocumentation
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 
-class DocumentationDDirectivesSpec extends WordSpec with DDirectivesSpec {
+class DocumentationDDirectivesSpec extends AnyWordSpec with DDirectivesSpec {
 
   "Category" must {
     "be applied for 1 segment" in {

--- a/src/test/scala/akka/http/documenteddsl/FormFieldDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/FormFieldDDirectivesSpec.scala
@@ -4,10 +4,10 @@ import DDirectives._
 import akka.http.documenteddsl.documentation.{JsonSchema, ParamDocumentation, RouteDocumentation}
 import akka.http.scaladsl.model.FormData
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 
-class FormFieldDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
+class FormFieldDDirectivesSpec extends AnyWordSpec with DDirectivesSpec with ScalatestRouteTest {
 
   "FormField" must {
     "be applied to route documentation" in {

--- a/src/test/scala/akka/http/documenteddsl/HeaderDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/HeaderDDirectivesSpec.scala
@@ -5,10 +5,10 @@ import akka.http.documenteddsl.documentation._
 import akka.http.scaladsl.model.ContentTypes
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 
-class HeaderDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
+class HeaderDDirectivesSpec extends AnyWordSpec with DDirectivesSpec with ScalatestRouteTest {
 
   "Header" must {
     "be applied to route documentation" in {

--- a/src/test/scala/akka/http/documenteddsl/MarshallingDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/MarshallingDDirectivesSpec.scala
@@ -5,11 +5,11 @@ import java.time.LocalDate
 import DDirectives._
 import akka.http.documenteddsl.documentation.{InDocumentation, JsonSchema, RouteDocumentation}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json._
 
-class MarshallingDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
+class MarshallingDDirectivesSpec extends AnyWordSpec with DDirectivesSpec with ScalatestRouteTest {
   import MarshallingDDirectivesSpec._
   import akka.http.scaladsl.marshallers.playjson.PlayJsonSupport._
 

--- a/src/test/scala/akka/http/documenteddsl/MethodDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/MethodDDirectivesSpec.scala
@@ -3,10 +3,10 @@ package akka.http.documenteddsl
 import DDirectives._
 import akka.http.documenteddsl.documentation.RouteDocumentation
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 
-class MethodDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
+class MethodDDirectivesSpec extends AnyWordSpec with DDirectivesSpec with ScalatestRouteTest {
 
   private def check(m: MethodDDirective): Unit = m.toString must {
     "be applied to documentation" in {

--- a/src/test/scala/akka/http/documenteddsl/ParameterDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/ParameterDDirectivesSpec.scala
@@ -3,10 +3,10 @@ package akka.http.documenteddsl
 import DDirectives._
 import akka.http.documenteddsl.documentation.{JsonSchema, ParamDocumentation, RouteDocumentation}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 
-class ParameterDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
+class ParameterDDirectivesSpec extends AnyWordSpec with DDirectivesSpec with ScalatestRouteTest {
 
   "Param" must {
     "be applied to route documentation" in {

--- a/src/test/scala/akka/http/documenteddsl/PathDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/PathDDirectivesSpec.scala
@@ -5,11 +5,11 @@ import java.time.LocalDate
 import akka.http.documenteddsl.DDirectives._
 import akka.http.documenteddsl.documentation._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
 
-class PathDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
+class PathDDirectivesSpec extends AnyWordSpec with DDirectivesSpec with ScalatestRouteTest {
 
   "PathPrefix" must {
     "be applied for 1 segment" in {

--- a/src/test/scala/akka/http/documenteddsl/SessionDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/SessionDDirectivesSpec.scala
@@ -6,10 +6,10 @@ import akka.http.javadsl.server.AuthorizationFailedRejection
 import akka.http.scaladsl.model.headers.Cookie
 import akka.http.scaladsl.server.Directive1
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 
-class SessionDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
+class SessionDDirectivesSpec extends AnyWordSpec with DDirectivesSpec with ScalatestRouteTest {
   import SessionDDirectivesSpec._
 
   "Session" must {

--- a/src/test/scala/akka/http/documenteddsl/UnmarshallingDDirectivesSpec.scala
+++ b/src/test/scala/akka/http/documenteddsl/UnmarshallingDDirectivesSpec.scala
@@ -7,11 +7,11 @@ import akka.http.documenteddsl.documentation.OutDocumentation._
 import akka.http.documenteddsl.documentation.{JsonSchema, OutDocumentation, RouteDocumentation}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.MustMatchers._
-import org.scalatest.WordSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.{Format, Json}
 
-class UnmarshallingDDirectivesSpec extends WordSpec with DDirectivesSpec with ScalatestRouteTest {
+class UnmarshallingDDirectivesSpec extends AnyWordSpec with DDirectivesSpec with ScalatestRouteTest {
   import UnmarshallingDDirectivesSpec._
 
   "Out" must {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "0.2.32-SNAPSHOT"


### PR DESCRIPTION
* update SBT plugins
* switch to tag based release process
* update actions in CI workflow
* drop Scala 2.12 support
* update Scala to 2.13.18
* update SBT to 1.12.14
* update mockito-core to 5.23.0
* update scalatest to 3.2.20
* update akka-http-play-json to 0.3.0
* update akka to 2.6.21 and akka-http to 10.2.10 (last open source versions before switch to BSL)