### PR TITLE
Bump autoschema to 2.0.0 (play-json 3)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val akkaStream        = "com.typesafe.akka"   %% "akka-stream"          % AkkaVersion
   val akkaStreamTestkit = "com.typesafe.akka"   %% "akka-stream-testkit"  % AkkaVersion % Test
   val akkaHttpPlayJson  = "com.evolutiongaming" %% "akka-http-play-json"  % "0.3.0"
-  val jsonSchema        = "com.evolutiongaming" %% "autoschema"           % "1.0.5"
+  val jsonSchema        = "com.evolutiongaming" %% "autoschema"           % "2.0.0"
   val scalaTest         = "org.scalatest"       %% "scalatest"            % "3.2.20" % Test
   val mockito           = "org.mockito"          % "mockito-core"         % "5.23.0" % Test
 }


### PR DESCRIPTION
autoschema 2.0.0 moves to org.playframework play-json 3.0.6. akka-http-play-json here is already 0.3.0, so this makes the whole artifact single-coordinate. This is the only route autoschema reaches coreservices by, so a release unblocks getting coreservices off com.typesafe.play.