### PR TITLE
Update README to 0.4.0, bump CI actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,12 +16,12 @@ jobs:
           - 2.13.18
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: coursier/cache-action@v6
+      - uses: coursier/cache-action@v8
 
       - name: setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/evolution-gaming/akka-http-documenteddsl/workflows/CI/badge.svg)](https://github.com/evolution-gaming/akka-http-documenteddsl/actions?query=workflow%3ACI)
 [![Coverage Status](https://coveralls.io/repos/github/evolution-gaming/akka-http-documenteddsl/badge.svg)](https://coveralls.io/github/evolution-gaming/akka-http-documenteddsl)
-[![version](https://api.bintray.com/packages/evolutiongaming/maven/akka-http-documenteddsl/images/download.svg) ](https://bintray.com/evolutiongaming/maven/akka-http-documenteddsl/_latestVersion)
 
 ## The Problem
  Want to provide [Swaggerrish](http://swagger.io/) api documentation of your app? Or [RAML](http://raml.org/)?
@@ -221,6 +220,6 @@ GET http://localhost:8080/api.json/14906C3B8B40240130BFA42E
 ## Setup
 **Sbt**
 ```scala
-resolvers += Resolver.bintrayRepo("evolutiongaming", "maven")
-libraryDependencies += "com.evolutiongaming" %% "akka-http-documenteddsl" % "_latestVersion"
+resolvers += "evolution" at "https://evolution.jfrog.io/artifactory/public"
+libraryDependencies += "com.evolutiongaming" %% "akka-http-documenteddsl" % "0.4.0"
 ```


### PR DESCRIPTION
Setup section now points to 0.4.0 and the Evolution artifactory repo instead of the defunct bintray one; removed the dead bintray version badge.

CI actions bumped off Node 20: checkout v4→v7, setup-java v4→v5, coursier/cache-action v6→v8. The release workflow's copies live in the shared scala-github-actions repo.